### PR TITLE
Fix AttributeError in Coordinator.stop() when env.create() fails before _proc is set

### DIFF
--- a/src/omnirec/runner/coordinator.py
+++ b/src/omnirec/runner/coordinator.py
@@ -68,6 +68,7 @@ class Coordinator:
         self._out_reader: Optional[OutputReader] = None
         self._err_reader: Optional[OutputReader] = None
         self._root: Optional[_RunnerService] = None
+        self._proc: Optional[subprocess.Popen] = None
 
         ensure_certs()
 
@@ -447,7 +448,8 @@ class Coordinator:
         if self._root is not None:
             self._root._shutdown()
 
-        # FIXME: self._proc might be None here
+        if self._proc is None:
+            return
         self._proc.terminate()
         try:
             self._proc.wait(5)


### PR DESCRIPTION
While running multi-seed experiments with AutoRecLab on top of OmniRec, we 
kept hitting a crash that turned out to be a bug in `Coordinator.stop()`. 
When `env.create()` fails — for example because the underlying environment 
manager cannot set things up — it calls `sys.exit(1)` internally. Since 
`SystemExit` is not caught by the `except Exception` handler in 
`Coordinator.run()`, it propagates into the `finally` block, which calls 
`self.stop()`. At that point `self._proc` was never assigned, because it 
is only set after `env.create()` succeeds — so `stop()` itself crashes with 
`AttributeError: 'Coordinator' object has no attribute '_proc'`. This 
secondary error overwrites the real traceback, hiding the actual root cause 
(the failed environment creation) behind a misleading, unrelated error. A 
`# FIXME: self._proc might be None here` comment already existed at this 
exact line, so the edge case was known but never fixed.

We reproduced this consistently: 6 out of 7 checkpoints in one of our runs 
failed with the identical traceback at `coordinator.py:451`, all caused by 
the same upstream `env.create()` failure:

File ".../omnirec/runner/coordinator.py", line 263, in start_runner
env.create()
File ".../omnirec/runner/envs.py", line 90, in _handle_proc
sys.exit(1)
SystemExit: 1
During handling of the above exception, another exception occurred:
File ".../omnirec/runner/coordinator.py", line 451, in stop
self._proc.terminate()
AttributeError: 'Coordinator' object has no attribute '_proc'

The fix is two minimal, self-contained changes: we initialize 
`self._proc = None` in `__init__` (consistent with `_out_reader`, 
`_err_reader`, and `_root`), and add an early return in `stop()` when 
`self._proc is None`, since there's nothing to terminate in that case. 
`self._root._shutdown()` still runs beforehand, so no other behavior 
changes. With this, a failed `env.create()` now surfaces its real error 
instead of being masked by an unrelated `AttributeError`.

This PR was submitted by **Group 1 (Team 1)**