### PR TITLE
feat: run-scoped results — document and expose current-run results alongside accumulated ones

### DIFF
--- a/docs/checkpointing.md
+++ b/docs/checkpointing.md
@@ -9,6 +9,7 @@ The checkpoint directory organizes experiments hierarchically:
 ```
 checkpoints/
 ├── progress.json                                    # Global progress tracker
+├── results.json                                     # Accumulated evaluation results
 ├── out.log                                          # Runner stdout logs
 ├── err.log                                          # Runner stderr logs
 └── {dataset-name}-{hash}/                          # Per dataset
@@ -24,6 +25,7 @@ checkpoints/
 **Key files:**
 
 - **`progress.json`**: Tracks experiment phases (Fit, Predict, Eval, Done) for each configuration. Enables resuming interrupted experiments.
+- **`results.json`**: Accumulated evaluation results of all runs that used this checkpoint directory. Automatically restored into the evaluator at the start of every run (see [Resuming Experiments](#resuming-experiments)).
 - **`predictions.json`**: Contains model predictions with columns: `user`, `item`, `score`, `rank`.
 - **`out.log` / `err.log`**: Runner process output for debugging.
 
@@ -67,6 +69,14 @@ Each experiment goes through four phases:
 4. **Done**: Experiment complete
 
 The `progress.json` file tracks the current phase for each experiment configuration. If interrupted, the next run resumes from the last incomplete phase.
+
+**Result Restoring**
+
+At the start of every run, the coordinator loads `results.json` from the checkpoint directory (if it exists) into the passed evaluator and logs how many result rows were restored. At the end of the run, the accumulated results are written back. As a consequence:
+
+- `evaluator.get_results()` returns the union of the current run's results and all previously saved results from the same checkpoint directory — even across separate processes and freshly created `Evaluator` instances.
+- Use the return value of `run_omnirec` or `evaluator.get_results(scope="run")` to get only the results evaluated during the current run.
+- Use a fresh checkpoint directory if you do not want previous results to be restored.
 
 **Cross-Validation Support**
 

--- a/docs/evaluator.md
+++ b/docs/evaluator.md
@@ -143,6 +143,25 @@ for dataset_id, df in evaluator.get_results().items():
 
 This format makes it easy to filter, aggregate, or export results for further analysis.
 
+## Result Semantics: Accumulated vs. Current Run
+
+The evaluator accumulates results across experiments and across successive runs. In addition, at the start of every run the coordinator automatically restores previously saved results from `results.json` in the checkpoint directory (see [Checkpointing and Results](checkpointing.md)). This means `get_results()` may also contain results from earlier runs and earlier processes that used the same checkpoint directory — even if the `Evaluator` instance was freshly created.
+
+To work only with the results of the current run, use the return value of [`run_omnirec`](api/runner_function.md#omnirec.util.run.run_omnirec) or call `get_results(scope="run")`:
+
+```python
+# Returns only the results evaluated during this call
+results = run_omnirec(datasets=dataset, plan=plan, evaluator=evaluator)
+
+# Equivalent: run-scoped results from the evaluator
+results = evaluator.get_results(scope="run")
+
+# All accumulated results, including those restored from the checkpoint directory
+all_results = evaluator.get_results()
+```
+
+Alternatively, use a fresh checkpoint directory to avoid restoring old results altogether.
+
 ## Saving and Loading Results
 
 Use [`save_results()`](api/evaluation_metrics.md#omnirec.runner.evaluation.Evaluator.save_results) to persist evaluation results to a JSON file after a run, and [`load_results()`](api/evaluation_metrics.md#omnirec.runner.evaluation.Evaluator.load_results) to restore them later without re-running experiments:

--- a/src/omnirec/runner/coordinator.py
+++ b/src/omnirec/runner/coordinator.py
@@ -124,9 +124,17 @@ class Coordinator:
             sys.exit(1)
 
         self._evaluator = evaluator
+        self._evaluator._start_run()
         self._results_path = self._checkpoint_dir / "results.json"
         if self._results_path.exists():
             self._evaluator.load_results(self._results_path)
+            num_restored = sum(
+                len(df) for df in self._evaluator.get_results().values()
+            )
+            logger.info(
+                f"Restored {num_restored} previous result rows from {self._results_path}. "
+                'get_results() includes them, get_results(scope="run") does not.'
+            )
 
         for current_algo, current_config_list in algorithm_configs:
             try:

--- a/src/omnirec/runner/evaluation.py
+++ b/src/omnirec/runner/evaluation.py
@@ -1,7 +1,7 @@
 import json
 import sys
 from pathlib import Path
-from typing import Iterable, Optional
+from typing import Iterable, Literal, Optional
 
 import pandas as pd
 from pandas import DataFrame
@@ -32,6 +32,7 @@ class Evaluator:
             metrics = [metrics]
         self._metrics = metrics
         self._results: dict[str, DataFrame] = {}
+        self._run_results: dict[str, DataFrame] = {}
 
     def run_evaluation(
         self,
@@ -69,8 +70,38 @@ class Evaluator:
         else:
             self._results[dataset] = pd.concat((old_df, new_df))
 
-    def get_results(self) -> dict[str, DataFrame]:
+        old_run_df = self._run_results.get(dataset)
+        if old_run_df is None:
+            self._run_results[dataset] = new_df
+        else:
+            self._run_results[dataset] = pd.concat((old_run_df, new_df))
+
+    def _start_run(self):
+        """Reset the run-scoped result store. Called by the coordinator at the
+        beginning of each run, before previous results are restored from the
+        checkpoint directory."""
+        self._run_results = {}
+
+    def get_results(
+        self, scope: Literal["all", "run"] = "all"
+    ) -> dict[str, DataFrame]:
         """Return evaluation results grouped by dataset.
+
+        Results accumulate in this Evaluator across experiments and across
+        successive runs. In addition, the coordinator restores previously saved
+        results from ``results.json`` in the checkpoint directory at the start
+        of every run (see :meth:`load_results`), so with ``scope="all"`` the
+        returned results also include results produced by earlier runs and
+        earlier processes that used the same checkpoint directory. Use
+        ``scope="run"`` to get only the results evaluated during the current
+        (most recent) run, or use a fresh checkpoint directory to avoid
+        restoring old results altogether.
+
+        Args:
+            scope: ``"all"`` (default) returns all accumulated results,
+                including results restored from the checkpoint directory.
+                ``"run"`` returns only the results evaluated since the start of
+                the current run.
 
         Returns:
             dict[str, DataFrame]:
@@ -84,6 +115,8 @@ class Evaluator:
                 - "k": cutoff for ranking metrics (e.g., NDCG@k), or None for non-ranking metrics (e.g., RMSE)
                 - "value": metric value
         """
+        if scope == "run":
+            return self._run_results
         return self._results
 
     def get_tables(self) -> list[Table]:
@@ -167,6 +200,8 @@ class Evaluator:
 
         Serialises the internal results dictionary to JSON so that results can be
         reloaded later with :meth:`load_results` without re-running experiments.
+        The coordinator calls this automatically at the end of every run to write
+        ``results.json`` in the checkpoint directory.
 
         Args:
             path (Path): Destination file path. The file is created or overwritten.
@@ -185,7 +220,11 @@ class Evaluator:
 
         Restores results that were written by :meth:`save_results`. After loading,
         :meth:`get_results` and :meth:`get_tables` work as if the experiments had
-        just finished.
+        just finished. The coordinator calls this automatically at the start of
+        every run when ``results.json`` exists in the checkpoint directory, so
+        previously saved results are restored into the passed Evaluator even if
+        it was freshly created. Restored results are not part of the run-scoped
+        results (``get_results(scope="run")``).
 
         Args:
             path (Path): Path to a JSON file previously written by :meth:`save_results`.

--- a/src/omnirec/util/run.py
+++ b/src/omnirec/util/run.py
@@ -1,6 +1,7 @@
 from os import PathLike
 from typing import Iterable, Optional, TypeVar
 
+from pandas import DataFrame
 from rich.console import Console
 
 from omnirec.data_variants import DataVariant
@@ -17,7 +18,7 @@ def run_omnirec(
     plan: ExperimentPlan,
     evaluator: Evaluator,  # TODO: Make optional
     slurm_script: Optional[PathLike | str] = None
-):
+) -> dict[str, DataFrame]:
     """Run the OmniRec framework with the specified datasets, experiment plan, and evaluator.
 
     Args:
@@ -26,6 +27,12 @@ def run_omnirec(
         evaluator (Evaluator): The evaluator to use for the experiment.
         slurm_script (Optional[PathLike | str]): Path to a SLURM script used to schedule experiments
             on an HPC cluster. If not provided, the experiments are run locally in normal mode.
+
+    Returns:
+        dict[str, DataFrame]: The results evaluated during this call, grouped by dataset
+            (see :meth:`~omnirec.runner.evaluation.Evaluator.get_results`). Results restored
+            from the checkpoint directory or produced by earlier calls are not included;
+            use ``evaluator.get_results()`` to retrieve all accumulated results.
     """
     if slurm_script is not None:
         # TODO:
@@ -37,3 +44,5 @@ def run_omnirec(
     for table in evaluator.get_tables():
         console = Console()
         console.print(table)
+
+    return evaluator.get_results(scope="run")

--- a/tests/test_evaluator.py
+++ b/tests/test_evaluator.py
@@ -1,0 +1,101 @@
+import pandas as pd
+import pytest
+
+from omnirec.metrics.base import Metric, MetricResult
+from omnirec.runner.evaluation import Evaluator
+
+
+class DummyMetric(Metric):
+    def __init__(self, name: str = "Dummy", ks: list[int] | None = None):
+        self._name = name
+        self._ks = ks or [5, 10]
+
+    def calculate(self, predictions: pd.DataFrame, test: pd.DataFrame) -> MetricResult:
+        return MetricResult(self._name, {k: 0.5 for k in self._ks})
+
+
+@pytest.fixture
+def frames():
+    predictions = pd.DataFrame({"user": [1], "item": [2], "score": [0.9], "rank": [1]})
+    test = pd.DataFrame({"user": [1], "item": [2], "rating": [5.0]})
+    return predictions, test
+
+
+def test_get_results_accumulates_across_evaluations(frames):
+    predictions, test = frames
+    evaluator = Evaluator(DummyMetric())
+
+    evaluator.run_evaluation("ds-a", "algo1", predictions, test)
+    evaluator.run_evaluation("ds-a", "algo2", predictions, test)
+    evaluator.run_evaluation("ds-b", "algo1", predictions, test)
+
+    results = evaluator.get_results()
+    assert set(results) == {"ds-a", "ds-b"}
+    assert len(results["ds-a"]) == 4  # 2 algorithms x 2 k values
+    assert len(results["ds-b"]) == 2
+
+
+def test_scope_all_includes_loaded_results(frames, tmp_path):
+    predictions, test = frames
+
+    first = Evaluator(DummyMetric())
+    first.run_evaluation("ds-a", "algo1", predictions, test)
+    results_path = tmp_path / "results.json"
+    first.save_results(results_path)
+
+    fresh = Evaluator(DummyMetric())
+    fresh.load_results(results_path)
+    fresh.run_evaluation("ds-b", "algo1", predictions, test)
+
+    all_results = fresh.get_results()
+    assert set(all_results) == {"ds-a", "ds-b"}
+    assert all_results["ds-a"].equals(first.get_results()["ds-a"])
+
+
+def test_scope_run_excludes_loaded_results(frames, tmp_path):
+    predictions, test = frames
+
+    first = Evaluator(DummyMetric())
+    first.run_evaluation("ds-a", "algo1", predictions, test)
+    results_path = tmp_path / "results.json"
+    first.save_results(results_path)
+
+    fresh = Evaluator(DummyMetric())
+    fresh._start_run()
+    fresh.load_results(results_path)
+    fresh.run_evaluation("ds-b", "algo1", predictions, test)
+
+    run_results = fresh.get_results(scope="run")
+    assert set(run_results) == {"ds-b"}
+    assert len(run_results["ds-b"]) == 2
+
+
+def test_start_run_resets_only_run_scope(frames):
+    predictions, test = frames
+    evaluator = Evaluator(DummyMetric())
+
+    evaluator.run_evaluation("ds-a", "algo1", predictions, test)
+    evaluator._start_run()
+    evaluator.run_evaluation("ds-b", "algo1", predictions, test)
+
+    assert set(evaluator.get_results(scope="run")) == {"ds-b"}
+    assert set(evaluator.get_results()) == {"ds-a", "ds-b"}
+
+
+def test_save_load_roundtrip(frames, tmp_path):
+    predictions, test = frames
+    evaluator = Evaluator(DummyMetric())
+    evaluator.run_evaluation("ds-a", "algo1", predictions, test, fold=0)
+    evaluator.run_evaluation("ds-a", "algo1", predictions, test, fold=1)
+
+    results_path = tmp_path / "results.json"
+    evaluator.save_results(results_path)
+
+    restored = Evaluator(DummyMetric())
+    restored.load_results(results_path)
+
+    original = evaluator.get_results()["ds-a"].reset_index(drop=True)
+    loaded = restored.get_results()["ds-a"].reset_index(drop=True)
+    assert loaded.astype(object).where(loaded.notna(), None).equals(
+        original.astype(object).where(original.notna(), None)
+    )


### PR DESCRIPTION
## Problem

`Evaluator.get_results()` returns results accumulated across runs: `Coordinator.run()`
restores `checkpoints/results.json` into the passed evaluator at the start of every run
and writes the union back at the end. As a result, even a freshly created `Evaluator`
in a new process silently returns results from earlier runs that used the same
checkpoint directory. This behavior was only hinted at in the `Evaluator.__init__`
docstring and not documented in `docs/`, and there was no way to obtain just the
results of the current call — the return value of `run_omnirec()` was unused.

## Motivation

We hit this in practice in AutoRecLab, where LLM agents generate and run OmniRec
experiments automatically: 3 out of 4 agents assumed `get_results()` returns only the
results of the current call. Because the checkpoint restore silently mixed in results
from earlier conditions, the extracted result tables contained rows from previous runs
(growing per-condition result blocks, and one condition whose "results" contained no
own rows at all). Notably, creating a fresh `Evaluator` per condition did not help,
since the coordinator restores `results.json` into it. This PR documents the
accumulating behavior explicitly and adds a first-class way to get exactly the
current run's results, which is the fix that would have prevented these errors.

## Changes (fully non-breaking)

- `Evaluator.get_results(scope="all" | "run")` — the default `"all"` is exactly the
  existing behavior; `"run"` returns only results evaluated during the current run
  (restored checkpoint results are excluded).
- `run_omnirec()` now returns the run-scoped results (its return value was previously
  unused).
- `Coordinator.run()` logs an INFO message with the number of restored result rows
  instead of restoring silently.
- Docs: `results.json` added to the checkpoint directory tree and key files in
  `docs/checkpointing.md`, with a new paragraph on result restoring; new
  "Result Semantics" section in `docs/evaluator.md`.
- New unit tests in `tests/test_evaluator.py` covering accumulation, both scopes,
  and the save/load roundtrip.

## Verification

- `pytest tests/` — 19 passed (14 existing + 5 new)
- `mkdocs build --strict` — clean
- Two-process check mirroring the coordinator's restore/save lines: process 1
  evaluates dataset A and saves `results.json`; process 2 with a fresh evaluator
  restores it and evaluates B → `get_results()` returns A+B (unchanged behavior),
  `get_results(scope="run")` returns only B.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
